### PR TITLE
Remove dead code

### DIFF
--- a/src/global_growth/core.clj
+++ b/src/global_growth/core.clj
@@ -35,11 +35,6 @@
     {:metadata metadata
      :results results}))
 
-(defn get-value
-  "Returns single value from API response"
-  [path query-params key]
-  (get-in (get-api path query-params) [:results 0 key]))
-
 (defn get-value-map
   "Returns relation of two keys from API response"
   [path query-params key1 key2]


### PR DESCRIPTION
We don't and won't use get-value function so removing it entirely.
